### PR TITLE
Ignore security advisories

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -133,18 +133,14 @@ jobs:
             php composer require ${{ env.PACKAGE_NAME }}:* --no-interaction --no-update
           docker compose exec -T \
             php composer require oxid-esales/oxideshop-demodata-ce:"${{ env.oxid-demo-data-version }}" --no-interaction --no-update
-        env:
-          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Install dependencies and reset shop
         run: |
-          docker compose exec -T php composer update --no-interaction
+          docker compose exec -T php composer update --no-interaction --no-security-blocking
           docker compose exec -T php bin/oe-console oe:database:reset \
             --db-host=mysql --db-port=3306 --db-name=example --db-user=root --db-password=root --force
           docker compose exec -T php bin/oe-console oe:setup:demodata
           docker compose exec -T php bin/oe-console oe:module:activate ${{ env.MODULE_IDS }}
-        env:
-          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Stop containers
         run: |
@@ -190,8 +186,6 @@ jobs:
           docker compose exec -T \
             --workdir=/var/www/test-module \
             php composer install
-        env:
-          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Run phpcs
         if: always()
@@ -199,8 +193,6 @@ jobs:
           docker compose exec -T \
             --workdir=/var/www/test-module \
             php composer phpcs
-        env:
-          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Run phpstan scan and show results
         id: phpstan
@@ -209,8 +201,6 @@ jobs:
           docker compose exec -T \
             --workdir=/var/www/test-module \
             php composer phpstan
-        env:
-          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Run phpstan scan and generate report for further processing
         if: always()
@@ -218,8 +208,6 @@ jobs:
           docker compose exec -T \
             --workdir=/var/www/test-module \
             php composer phpstan-report
-        env:
-          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Stop containers
         if: always()

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -185,7 +185,7 @@ jobs:
         run: |
           docker compose exec -T \
             --workdir=/var/www/test-module \
-            php composer install
+            php composer install --no-security-blocking
 
       - name: Run phpcs
         if: always()

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -133,6 +133,8 @@ jobs:
             php composer require ${{ env.PACKAGE_NAME }}:* --no-interaction --no-update
           docker compose exec -T \
             php composer require oxid-esales/oxideshop-demodata-ce:"${{ env.oxid-demo-data-version }}" --no-interaction --no-update
+        env:
+          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Install dependencies and reset shop
         run: |
@@ -141,6 +143,8 @@ jobs:
             --db-host=mysql --db-port=3306 --db-name=example --db-user=root --db-password=root --force
           docker compose exec -T php bin/oe-console oe:setup:demodata
           docker compose exec -T php bin/oe-console oe:module:activate ${{ env.MODULE_IDS }}
+        env:
+          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Stop containers
         run: |
@@ -186,6 +190,8 @@ jobs:
           docker compose exec -T \
             --workdir=/var/www/test-module \
             php composer install
+        env:
+          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Run phpcs
         if: always()
@@ -193,6 +199,8 @@ jobs:
           docker compose exec -T \
             --workdir=/var/www/test-module \
             php composer phpcs
+        env:
+          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Run phpstan scan and show results
         id: phpstan
@@ -201,6 +209,8 @@ jobs:
           docker compose exec -T \
             --workdir=/var/www/test-module \
             php composer phpstan
+        env:
+          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Run phpstan scan and generate report for further processing
         if: always()
@@ -208,6 +218,8 @@ jobs:
           docker compose exec -T \
             --workdir=/var/www/test-module \
             php composer phpstan-report
+        env:
+          COMPOSER_NO_SECURITY_BLOCKING: 1
 
       - name: Stop containers
         if: always()

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
             "oxid-esales/oxideshop-composer-plugin": false
         },
         "audit": {
-            "block-insecure": false
+            "ignore": ["smarty/smarty"]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "phpstan/phpstan": "^1.9.14",
         "squizlabs/php_codesniffer": "3.*",
         "phpmd/phpmd": "^2.11",
-        "oxid-esales/oxideshop-ce": "dev-b-7.0.x"
+        "oxid-esales/oxideshop-ce": "7.0.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
OXID requires outdated packages with security issues.
These packages prevent us from releasing a new version.
The only way to fix that is to ignore the security advisories.