### PR TITLE
fix: When product is changed mark all variants also as changed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "phpstan/phpstan": "^1.9.14",
         "squizlabs/php_codesniffer": "3.*",
         "phpmd/phpmd": "^2.11",
-        "oxid-esales/oxideshop-ce": "7.0.*"
+        "oxid-esales/oxideshop-ce": "7.0.*",
+        "phpunit/phpunit": "^9.1.1"
     },
     "autoload": {
         "psr-4": {
@@ -66,7 +67,8 @@
             "oxid-esales/oxideshop-composer-plugin": false
         },
         "audit": {
-            "ignore": ["smarty/smarty"]
+            "ignore": ["smarty/smarty"],
+            "block-insecure": false
         }
     }
 }

--- a/src/RevisionHandler/AbstractModelDataExtractor.php
+++ b/src/RevisionHandler/AbstractModelDataExtractor.php
@@ -10,19 +10,30 @@ abstract class AbstractModelDataExtractor implements ModelDataExtractorInterface
     /**
      * @param string                 $type
      * @param string                 $objectId
-     * @param DateTimeInterface|null $changed
-     * @param int|null               $revision
      *
      * @return array<Revision>
      */
     protected function buildRevision(
         string $type,
         string $objectId,
-        ?DateTimeInterface $changed = null,
-        ?int $revision = null
     ): array {
-        $key = sprintf('%s-%s', $type, $objectId);
+        return $this->buildRevisions([$objectId => $type]);
+    }
 
-        return [$key => new Revision($type, $objectId, $changed, $revision)];
+    /**
+     * @param array<string, string>  $input
+     *
+     * @return array<Revision>
+     */
+    protected function buildRevisions(
+        array $input,
+    ): array {
+        $revisions = [];
+        foreach ($input as $objectId => $type) {
+            $key = sprintf('%s-%s', $type, $objectId);
+            $revisions[$key] = new Revision($type, $objectId);
+        }
+
+        return $revisions;
     }
 }

--- a/src/RevisionHandler/Extractor/Article.php
+++ b/src/RevisionHandler/Extractor/Article.php
@@ -16,10 +16,19 @@ class Article extends AbstractModelDataExtractor
      */
     public function extract(BaseModel $model): array
     {
-        return $this->buildRevision(
-            $model->getParentId() ? Revision::TYPE_VARIANT : Revision::TYPE_PRODUCT,
-            $model->getId()
-        );
+        $isParentArticle = !$model->getParentId();
+        $revisionInput = [];
+        if ($isParentArticle) {
+            $revisionInput[$model->getId()] = Revision::TYPE_PRODUCT;
+            foreach ($model->getVariantIds(false) as $variantId) {
+                $revisionInput[$variantId] = Revision::TYPE_VARIANT;
+            }
+        } else {
+            $revisionInput[$model->getParentId()] = Revision::TYPE_PRODUCT;
+            $revisionInput[$model->getId()] = Revision::TYPE_VARIANT;
+        }
+
+        return $this->buildRevisions($revisionInput);
     }
 
     /**

--- a/tests/Integration/RevisionHandler/Extractor/ArticleTest.php
+++ b/tests/Integration/RevisionHandler/Extractor/ArticleTest.php
@@ -34,18 +34,16 @@ class ArticleTest extends TestCase
         $this->assertFalse($actual);
     }
 
-    /**
-     * @return void
-     * @dataProvider provideTestData
-     */
-    public function testReturnsRevisionObject(string $parentId, string $expectedType): void
+    public function testReturnsRevisionForParentWithoutVariants(): void
     {
         $article = $this->createMock(OxidArticle::class);
-        $article->method('getParentId')->willReturn($parentId);
-        $article->method('getId')->willReturn('phpunit42');
+        $article
+            ->method('getParentId')->willReturn('')
+            ->method('getId')->willReturn('phpunit-parent')
+            ->method('getVariants')->willReturn([]);
 
         $articleExtractor = new Article();
-        $actual = $articleExtractor->extract($article);
+        $actual           = $articleExtractor->extract($article);
 
         $changed = new DateTimeImmutable();
 
@@ -54,16 +52,81 @@ class ArticleTest extends TestCase
         }
 
         $expected = [
-            $expectedType . '-phpunit42' => new Revision($expectedType, 'phpunit42', $changed)
+            Revision::TYPE_PRODUCT . '-phpunit-parent' => new Revision(
+                Revision::TYPE_PRODUCT,
+                'phpunit-parent',
+                $changed,
+            ),
         ];
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
-    public function provideTestData(): array
+
+    public function testReturnsRevisionForParentWithVariants(): void
     {
-        return [
-            'Testing product' => ['', Revision::TYPE_PRODUCT],
-            'Testing variant' => ['phpunit21', Revision::TYPE_VARIANT]
+        $article = $this->createMock(OxidArticle::class);
+        $article
+            ->method('getParentId')->willReturn('')
+            ->method('getId')->willReturn('phpunit-parent')
+            ->method('getVariantIds')->willReturn(['phpunit-variant1', 'phpunit-variant2']);
+
+        $articleExtractor = new Article();
+        $actual           = $articleExtractor->extract($article);
+
+        $changed = new DateTimeImmutable();
+
+        foreach ($actual as $revision) {
+            $revision->changed = $changed;
+        }
+
+        $expected = [
+            Revision::TYPE_PRODUCT . '-phpunit-parent'   => new Revision(
+                Revision::TYPE_PRODUCT,
+                'phpunit-parent',
+                $changed,
+            ),
+            Revision::TYPE_VARIANT . '-phpunit-variant1' => new Revision(
+                Revision::TYPE_VARIANT,
+                'phpunit-variant1',
+                $changed,
+            ),
+            Revision::TYPE_VARIANT . '-phpunit-variant2' => new Revision(
+                Revision::TYPE_VARIANT,
+                'phpunit-variant2',
+                $changed,
+            ),
         ];
+        $this->assertEqualsCanonicalizing($expected, $actual);
+    }
+
+    public function testReturnsRevisionObjectsForVariant(): void
+    {
+        $article = $this->createMock(OxidArticle::class);
+        $article
+            ->method('getParentId')->willReturn('phpunit-parent')
+            ->method('getId')->willReturn('phpunit-variant1');
+
+        $articleExtractor = new Article();
+        $actual           = $articleExtractor->extract($article);
+
+        $changed = new DateTimeImmutable();
+
+        foreach ($actual as $revision) {
+            $revision->changed = $changed;
+        }
+
+        $expected = [
+            Revision::TYPE_PRODUCT . '-phpunit-parent'   => new Revision(
+                Revision::TYPE_PRODUCT,
+                'phpunit-parent',
+                $changed,
+            ),
+            Revision::TYPE_VARIANT . '-phpunit-variant1' => new Revision(
+                Revision::TYPE_VARIANT,
+                'phpunit-variant1',
+                $changed,
+            ),
+        ];
+        $this->assertEqualsCanonicalizing($expected, $actual);
     }
 }

--- a/tests/Integration/RevisionHandler/Extractor/ArticleTest.php
+++ b/tests/Integration/RevisionHandler/Extractor/ArticleTest.php
@@ -37,10 +37,9 @@ class ArticleTest extends TestCase
     public function testReturnsRevisionForParentWithoutVariants(): void
     {
         $article = $this->createMock(OxidArticle::class);
-        $article
-            ->method('getParentId')->willReturn('')
-            ->method('getId')->willReturn('phpunit-parent')
-            ->method('getVariants')->willReturn([]);
+        $article->method('getParentId')->willReturn('');
+        $article->method('getId')->willReturn('phpunit-parent');
+        $article->method('getVariantIds')->willReturn([]);
 
         $articleExtractor = new Article();
         $actual           = $articleExtractor->extract($article);
@@ -65,10 +64,9 @@ class ArticleTest extends TestCase
     public function testReturnsRevisionForParentWithVariants(): void
     {
         $article = $this->createMock(OxidArticle::class);
-        $article
-            ->method('getParentId')->willReturn('')
-            ->method('getId')->willReturn('phpunit-parent')
-            ->method('getVariantIds')->willReturn(['phpunit-variant1', 'phpunit-variant2']);
+        $article->method('getParentId')->willReturn('');
+        $article->method('getId')->willReturn('phpunit-parent');
+        $article->method('getVariantIds')->willReturn(['phpunit-variant1', 'phpunit-variant2']);
 
         $articleExtractor = new Article();
         $actual           = $articleExtractor->extract($article);
@@ -102,9 +100,8 @@ class ArticleTest extends TestCase
     public function testReturnsRevisionObjectsForVariant(): void
     {
         $article = $this->createMock(OxidArticle::class);
-        $article
-            ->method('getParentId')->willReturn('phpunit-parent')
-            ->method('getId')->willReturn('phpunit-variant1');
+        $article->method('getParentId')->willReturn('phpunit-parent');
+        $article->method('getId')->willReturn('phpunit-variant1');
 
         $articleExtractor = new Article();
         $actual           = $articleExtractor->extract($article);

--- a/tests/Integration/RevisionHandler/ModelDataExtractorTest.php
+++ b/tests/Integration/RevisionHandler/ModelDataExtractorTest.php
@@ -16,15 +16,10 @@ use PHPUnit\Framework\TestCase;
 class ModelDataExtractorTest extends TestCase
 {
     /**
-     * @param string $productId
-     * @param string $parentId
-     * @param string $expectedType
-     *
-     * @return void
      * @throws ModelNotSupportedException
      * @dataProvider provideProducts
      */
-    public function testCanExtractDataFromProduct(string $productId, string $parentId, string $expectedType): void
+    public function testCanExtractDataFromProduct(string $productId, string $parentId): void
     {
         $categoryExtractor = new Category(
             $this->createMock(Connection::class),
@@ -48,9 +43,16 @@ class ModelDataExtractorTest extends TestCase
         }
 
         $expected = [
-            Revision::TYPE_PRODUCT . '-phpunit21' => new Revision(Revision::TYPE_PRODUCT, 'phpunit21', $changed),
-            $expectedType . '-phpunit42' => new Revision($expectedType, 'phpunit42', $changed),
+            Revision::TYPE_PRODUCT . '-phpunit42' => new Revision(Revision::TYPE_PRODUCT, 'phpunit42', $changed),
         ];
+
+        if ($parentId) {
+            $expected = [
+                Revision::TYPE_PRODUCT . '-phpunit21' => new Revision(Revision::TYPE_PRODUCT, 'phpunit21', $changed),
+                Revision::TYPE_VARIANT . '-phpunit42' => new Revision(Revision::TYPE_VARIANT, 'phpunit42', $changed),
+            ];
+        }
+
 
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
@@ -58,8 +60,8 @@ class ModelDataExtractorTest extends TestCase
     public function provideProducts(): array
     {
         return [
-            ['phpunit42', '', Revision::TYPE_PRODUCT],
-            ['phpunit42', 'phpunit21', Revision::TYPE_VARIANT],
+            ['phpunit42', ''],
+            ['phpunit42', 'phpunit21'],
         ];
     }
 }

--- a/tests/Integration/RevisionHandler/ModelDataExtractorTest.php
+++ b/tests/Integration/RevisionHandler/ModelDataExtractorTest.php
@@ -48,6 +48,7 @@ class ModelDataExtractorTest extends TestCase
         }
 
         $expected = [
+            Revision::TYPE_PRODUCT . '-phpunit21' => new Revision(Revision::TYPE_PRODUCT, 'phpunit21', $changed),
             $expectedType . '-phpunit42' => new Revision($expectedType, 'phpunit42', $changed),
         ];
 


### PR DESCRIPTION
- **Mark variants as changed when parent is updated in database (#29)**
- **fix: Update tests**
